### PR TITLE
Updated eslint-config-springworks to version 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bunyan": "1.5.1",
     "coveralls": "2.11.4",
     "eslint": "1.6.0",
-    "eslint-config-springworks": "3.1.1",
+    "eslint-config-springworks": "3.2.0",
     "eslint-plugin-mocha": "1.0.0",
     "istanbul": "0.3.21",
     "mocha": "2.3.3"


### PR DESCRIPTION
:rocket:

eslint-config-springworks just published version 3.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 5 commits (ahead by 5, behind by 0).

- [d337dd4](https://github.com/Springworks/eslint-config-springworks/commit/d337dd418121526831e530255e748af112d835cb): 3.2.0
- [fdd3204](https://github.com/Springworks/eslint-config-springworks/commit/fdd3204d2153d0614b6231f897083448632f0b05): Merge pull request #23 from Springworks/no-bluebird
- [9377160](https://github.com/Springworks/eslint-config-springworks/commit/93771606feebf4683c3880c47e5ca17bac26eb97): Disallow use of the bluebird module
- [378b433](https://github.com/Springworks/eslint-config-springworks/commit/378b433ef97ae3ee4e5b9f6362e66886bed6f375): Merge pull request #22 from Springworks/greenkeeper-eslint-1.6.0
- [21d654b](https://github.com/Springworks/eslint-config-springworks/commit/21d654b609da8d68d6f37d56d390c035d6e04c31): chore(package): update eslint to version 1.6.0

See the [full diff](https://github.com/Springworks/eslint-config-springworks/compare/350c48d51e38e17621bb3d9fa77ee4b9a60da463...d337dd418121526831e530255e748af112d835cb).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>